### PR TITLE
Faz leitura dos dados do IPCA no Json, trata e salva em delta

### DIFF
--- a/src/Tabela_IPCA.ipynb
+++ b/src/Tabela_IPCA.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "16283e0f-ba45-4c39-b12f-d10479353ded",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#importa bibliotecas\n",
+    "from pyspark.sql.functions import col, to_date\n",
+    "\n",
+    "# Lê os dados brutos da camada bronze\n",
+    "df_bronze = spark.read.json('/Volumes/raw/ipca_bronze/ipca_raw')\n",
+    "\n",
+    "# Cria o schema (caso ainda não exista)\n",
+    "spark.sql(\"CREATE SCHEMA IF NOT EXISTS silver\")\n",
+    "\n",
+    "# Dropar a tabela caso já exista com schema antigo\n",
+    "spark.sql(\"DROP TABLE IF EXISTS silver.ipca_silver\")\n",
+    "\n",
+    "# Tratamento: conversão de tipos\n",
+    "df_silver = (df_bronze\n",
+    "    .withColumn(\"data\", to_date(col(\"data\"), \"dd/MM/yyyy\"))\n",
+    "    .withColumn(\"valor\", col(\"valor\").cast(\"double\"))  \n",
+    "    .dropDuplicates()        \n",
+    "    .na.drop()                                        \n",
+    ")\n",
+    "\n",
+    "# Salva o dataframe tratado como tabela delta na camada silver\n",
+    "(df_silver.distinct()  # remove duplicatas\n",
+    "   .coalesce(1) # grava em um único arquivo (opcional)\n",
+    "   .write\n",
+    "   .format('delta')\n",
+    "   .mode('overwrite')\n",
+    "   .saveAsTable('silver.ipca_silver')  # salva no catálogo dentro do schema silver\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "Tabela_IPCA",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/ingestao_IPCA.ipynb
+++ b/src/ingestao_IPCA.ipynb
@@ -24,7 +24,7 @@
     "import datetime as dt\n",
     "\n",
     "# Define a URL da API do Banco Central que traz a série histórica do IPCA em formato JSON\n",
-    "url = 'https://api.bcb.gov.br/dados/serie/bcdata.sgs.10844/dados?formato=json?limit=10000'\n",
+    "url = 'https://api.bcb.gov.br/dados/serie/bcdata.sgs.10844/dados?formato=json'\n",
     "\n",
     "# Realiza a requisição GET para a API e armazena a resposta na variável 'IPCA'\n",
     "IPCA = requests.get(url)\n",


### PR DESCRIPTION
1 - Leitura de dados brutos do IPCA da camada bronze (JSON) 2 - Conversão dos tipos de dados (string para date e double) 3 - Remoção de duplicatas e valores nulos
4 - Escrita em tabela Delta na camada silver
5 - Criação automática do schema silver se não existir 6 - Inclusão de overwrite para garantir atualização do dataset tratado